### PR TITLE
Spring Bootのバージョンアップと依存性の整理

### DIFF
--- a/dbflute_maihamadb/dfprop/databaseInfoMap.dfprop
+++ b/dbflute_maihamadb/dfprop/databaseInfoMap.dfprop
@@ -16,7 +16,7 @@
 #
 map:{
     ; driver   = com.mysql.jdbc.Driver
-    ; url      = jdbc:mysql://localhost:3306/maihamadb
+    ; url      = jdbc:mysql://localhost:3306/maihamadb?useSSL=false
     ; schema   = 
     ; user     = maihamadb
     ; password = maihamadb

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
 	<properties>
 		<dbflute.version>1.2.0</dbflute.version>
 		<mysql.jdbc.version>5.1.46</mysql.jdbc.version>
-		<spring.version>5.1.1.RELEASE</spring.version>
-		<spring.boot.version>1.5.8.RELEASE</spring.boot.version>
+		<!-- Spring Bootのバージョンはparentでまとめて指定する -->
 		<utflute.version>0.8.9</utflute.version>
 	</properties>
 
@@ -167,10 +166,16 @@
 	    </repository>
 	</repositories>
 
+	<!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
+	<!--                                                                Main Framework -->
+	<!--                                                                 = = = = = = = -->
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.1.6.RELEASE</version>
+	</parent>
+
 	<dependencies>
-		<!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
-		<!--                                                                Main Framework -->
-		<!--                                                                 = = = = = = = -->
 		<!-- dbflute -->
 		<dependency>
 			<groupId>org.dbflute</groupId>
@@ -184,47 +189,22 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- spring -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<version>${spring.version}</version>
-		</dependency>
-
 		<!-- spring boot -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency> <!-- for thymeleaf -->
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency> <!-- for spring security -->
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
-			<version>${spring.boot.version}</version>
 		</dependency>
-
-		<!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
-		<!--                                                               Partner Library -->
-		<!--                                                               = = = = = = = = -->
-		<dependency> <!-- for JDBC basic handling -->
-			<groupId>commons-dbcp</groupId>
-			<artifactId>commons-dbcp</artifactId>
-			<version>1.3</version>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 
 		<!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,6 @@ logging.level.org.springframework.jdbc.datasource.DataSourceTransactionManager =
 #                                                                                 ========
 # the component of 'dataSource' is registered by this settings (and dbcp in pom.xml)
 spring.datasource.driverClassName = com.mysql.jdbc.Driver
-spring.datasource.url = jdbc:mysql://localhost:3306/maihamadb
+spring.datasource.url = jdbc:mysql://localhost:3306/maihamadb?useSSL=false
 spring.datasource.username = maihamadb
 spring.datasource.password = maihamadb

--- a/src/test/java/org/docksidestage/unit/JdbcBeansJavaConfig.java
+++ b/src/test/java/org/docksidestage/unit/JdbcBeansJavaConfig.java
@@ -17,7 +17,7 @@ package org.docksidestage.unit;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,14 +35,12 @@ public class JdbcBeansJavaConfig {
 
     @Bean(name = "dataSource")
     public DataSource createDataSource() {
-        BasicDataSource ds = new BasicDataSource();
+        HikariDataSource ds = new HikariDataSource();
         ds.setDriverClassName("com.mysql.jdbc.Driver");
-        ds.setUrl("jdbc:mysql://localhost:3306/maihamadb");
+        ds.setJdbcUrl("jdbc:mysql://localhost:3306/maihamadb");
         ds.setUsername("maihamadb");
         ds.setPassword("maihamadb");
-        // you can try abandoned settings here
-        //ds.setRemoveAbandoned(true);
-        //ds.setRemoveAbandonedTimeout(2);
+
         return ds;
     }
 


### PR DESCRIPTION
# 対応内容

https://dbflute.slack.com/archives/CAPMGTU6P/p1561297623002400?thread_ts=1561265860.000600&cid=CAPMGTU6P

- Spring Bootのバージョンが1.5系で少し古かったので最新にバージョンアップ
- 合わせて依存性を整理して、pomの書き方をよりSpring Bootらしく
- Commons DBCPをやめてSpring Boot 2標準のHikariCpに更新
    - サンプルなのでここまでしなくてもなのですが、性能が良くなるのでより本番らしいスタイルで
- ReplaceSchema時にOpenJDK11の問題でデータベースのコネクション終了時にSSLExceptionが発生したので、JDBC URLに `useSSL=false` を追加

詳細はコミットログを参照ください。

# 動作環境

下記で確認しています。JDKはおそらく8でも大丈夫かと思いますが確認取れていません。

brewでインストールするとMySQLが8, OpenJDK12になるので、最初から環境構築する人はバージョンに注意が必要です。

- Mac OS Mojave 
- OpenJDK 11
- MySQL 5.7
- IntellJ Idea 2019.01

# 動作確認

1. [x] Spring Bootが起動すること
1. [x] ログインが起動すること
1. [x] `mvn test` でテストが正常終了すること


# 対応しなかったこと

- テスト用に `application.properties` を作る
- pom.xmlのJavaバージョンを8から11にアップデートする