### PR TITLE
実行ユーザをrootではなくmaihamadbに修正する

### DIFF
--- a/dbflute_maihamadb/dfprop/databaseInfoMap.dfprop
+++ b/dbflute_maihamadb/dfprop/databaseInfoMap.dfprop
@@ -18,8 +18,8 @@ map:{
     ; driver   = com.mysql.jdbc.Driver
     ; url      = jdbc:mysql://localhost:3306/maihamadb?useSSL=false
     ; schema   = 
-    ; user     = root
-    ; password =
+    ; user     = maihamadb
+    ; password = maihamadb
 
     # /- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # o propertiesMap: (NotRequired - Default map:{})


### PR DESCRIPTION
# 背景

#19 がmasterマージされた後、実行ユーザがrootになっていたので修正しました。

https://dbflute.slack.com/archives/CAPMGTU6P/p1562143901003500?thread_ts=1561265860.000600&cid=CAPMGTU6P

rootでも良いのですが、下記の理由でrootでない方が良いと思います。

- MySQLのrootユーザのパスワードが環境やインストール方法によって異なるため
- ReplaceSchemaで生成するmaihabadbユーザだと、どの環境で実行しても利用できるため
- 機能開発ブランチで暫定的な修正がmasterマージされているのもちょっと引っかからないでもないです (老婆ですみません><)

自分も #18 で `useSSL=true` を追加したりしていますが、ローカルでSSL強制はないのと、OpenJDK11でエラーになるので実害はないのですが…。

rootは環境によっては動かなくなるのでちょっと気になりました。

# 動作確認

- [x] MySQLのmaihamadbユーザが利用できる状態で `manage.sh` を実行し、ReplaceSchemaが正常終了すること