### PR TITLE
ログインできない不具合修正

### DIFF
--- a/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
+++ b/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
@@ -8,7 +8,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.MessageDigestPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.ForwardAuthenticationFailureHandler;
 
@@ -56,8 +56,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         auth.userDetailsService(userDetailService).passwordEncoder(passwordEncoder()); // 既存のsampleプロジェクトに合わせる
     }
 
+    /**
+     * パスワードエンコーダを生成する.
+     * 最近のSpringだとBCryptを推奨しているがセキュリティ要件に合わせること.
+     * harborに合わせてSHA-256を利用する.
+     * 非推奨だが削除予定はないのでSpring Security標準付属のエンコーダを利用した.
+     *
+     * https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#other-passwordencoders
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new MessageDigestPasswordEncoder("SHA-256");
     }
 }


### PR DESCRIPTION
# 対応内容

ログインできなかったのはパスワードのエンコード方式が異なっていたので、harborに合わせてsha-256に修正

コメントに書いた通り非推奨ですが削除予定はないので、Spring Security標準付属のパスワードエンコーダでsha-256対応しました

# 動作確認

- [x] ログイン画面を開いて ID:Pixy password: sea を入力してログインできること
- [x] ログイン画面を開いて ID: Pixt password: se を入力してログインできないこと

# その他

- ログアウトしたら404エラーになったのですが、プルリクでは修正していません

