### PR TITLE
ログアウトすると404エラーになるのを修正

### DIFF
--- a/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
+++ b/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         // #for_now for test, enable later by jflute
+        // @formatter:off
         http.authorizeRequests()
                 .antMatchers("/signin", "/signin/", "/signup", "/signup/", "/product/list", "/product/list/")
                 .permitAll()
@@ -36,7 +37,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest()
                 .authenticated();
 
-        http.formLogin().loginPage("/signin")
+        http.formLogin()
+                .loginPage("/signin")
                 .loginProcessingUrl("/signin")
                 .defaultSuccessUrl("/member/list")
                 .failureUrl("/signin")
@@ -44,8 +46,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .usernameParameter("account")
                 .passwordParameter("password")
                 .permitAll()
-                .and().logout().logoutUrl("/signout/").logoutSuccessUrl("/signin/")
+                .and()
+             .logout()
+                .logoutUrl("/signout/")
+                .logoutSuccessUrl("/signin/")
                 .permitAll();
+        // @formatter:on
     }
 
     @Autowired

--- a/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
+++ b/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest()
                 .authenticated();
 
-        http.formLogin()
+        http.formLogin().loginPage("/signin")
                 .loginProcessingUrl("/signin")
                 .defaultSuccessUrl("/member/list")
                 .failureUrl("/signin")
@@ -44,10 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .usernameParameter("account")
                 .passwordParameter("password")
                 .permitAll()
-                .loginPage("/signin")
-                .and()
-                .logout()
-                .logoutSuccessUrl("/login")
+                .and().logout().logoutUrl("/signout/").logoutSuccessUrl("/signin/")
                 .permitAll();
     }
 

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -26,8 +26,7 @@
 					<ul class="child">
 						<li><a th:href="@{/profile/}" href="#">Profile</a></li>
                         <li>
-                            <form method="POST" name="logout" th:action="@{/signout/}"><a href="javascript:logout.submit()">Sign out</a>
-                            </form>
+                            <form method="POST" name="logout" th:action="@{/signout/}"><a href="javascript:logout.submit()">Sign out</a></form>
                         </li>
 					</ul>
 				</li>

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -25,7 +25,10 @@
 					<p th:unless="${headerBean.isLogin}" class="nameHeader">Welcome, Mr.Guest</p>
 					<ul class="child">
 						<li><a th:href="@{/profile/}" href="#">Profile</a></li>
-						<li><a th:href="@{/signout/}" href="#">Sign out</a></li>
+                        <li>
+                            <form method="POST" name="logout" th:action="@{/signout/}"><a href="javascript:logout.submit()">Sign out</a>
+                            </form>
+                        </li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
# 対応内容

ログアウトすると404エラーになるのを修正しました。

- Spring Securityではログアウトは標準だとPOSTリクエストのため、ヘッダにあるログアウトリンクをformに修正。ログアウトクリック時にformがpostされるよう修正
  - https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#csrf-logout
- Spring SecurityのログアウトのURLはデフォルトだと /logout で、ヘッダのリンク /signout/ と不一致だった
  - https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#logout-java-configuration
- わかりやすさのため [ガイド](https://spring.io/guides/gs/securing-web/) に合わせてSpring Security Configの書き方を改善しました
  - ログイン画面の指定を上に移動
  - インデントを修正

詳細はコミットを参照ください。

# 動作確認

- [x] ログイン後、ヘッダの `sign out` をクリックするとログイン画面に戻ること

# その他

ログアウト後、ログイン画面のユーザ名の表示が異なるので修正が必要です。
harborだと `Welcome, Guest` になりますが、 `Hello, ログインしたユーザ名` になってしまいます。
Spring SecurityのログアウトだけではHeaderBeanがクリアされていないようです。
