### PR TITLE
DBFluteとSpring Bootを2020/08の最新にアップグレード

### DIFF
--- a/dbflute_maihamadb/_project.bat
+++ b/dbflute_maihamadb/_project.bat
@@ -2,7 +2,7 @@
 
 set ANT_OPTS=-Xmx512m
 
-set DBFLUTE_HOME=..\mydbflute\dbflute-1.x
+set DBFLUTE_HOME=..\mydbflute\dbflute-1.2.3
 
 set MY_PROPERTIES_PATH=build.properties
 

--- a/dbflute_maihamadb/_project.sh
+++ b/dbflute_maihamadb/_project.sh
@@ -2,7 +2,7 @@
 
 export ANT_OPTS=-Xmx512m
 
-export DBFLUTE_HOME=../mydbflute/dbflute-1.x
+export DBFLUTE_HOME=../mydbflute/dbflute-1.2.3
 
 export MY_PROPERTIES_PATH=build.properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<inceptionYear>2014</inceptionYear>
 
 	<properties>
-		<dbflute.version>1.2.0</dbflute.version>
+		<dbflute.version>1.2.3</dbflute.version>
 		<!-- Spring Bootのバージョンはparentでまとめて指定する -->
 		<utflute.version>0.8.9</utflute.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
+		<version>2.3.2.RELEASE</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>


### PR DESCRIPTION
# 対応
DBFluteを1.2.3, Spring Boot を2.3.2にアップグレードしました。2020/08/11時点の最新です。

#27, #28, #29 とさほど違いはありません。

## いつものバージョンアップと違うこと
### その1
Mac OSで `public.properties` がダウンロードできなかったのですがMac OSのセキュリティ設定の問題でした。
うっかりハマったのでQiitaにしたためておきました。

https://qiita.com/zoosm3/items/22d389aa262b24e43c3d

### その2
いつもSpring Bootのバージョンをどこで指定するか迷うので、pomにコメントを入れました。

# 動作確認
## DBFlute
- [x] `sh manage.sh 94` でエラーなくバージョンアップできること
   - 一度エラーになりましたがMac OSのセキュリティ設定が原因でした
- [x] 1.2.3にバージョンアップ後、`sg manage.sh 0` でreplace schemaできること


## Spring Boot
- [x] 起動、ログイン、ログアウト、Add Memberできること

