### PR TITLE
Spring Bootを2020/11/12リリースの2.4.0にバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>2.3.5.RELEASE</version>
+		<version>2.4.0</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>


### PR DESCRIPTION
# 対応内容

件名の通り、Spring Bootを2020/11/12リリースの2.4.0にバージョンアップしました。

## 変更点
2.4.0よりバージョンの形式が変わったため、 `2.4.0.RELEASE` ではなく `2.4.0` で正しいです。

https://spring.io/blog/2020/04/30/updates-to-spring-versions