### PR TITLE
dependabotで依存性更新検知を自動化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: '21:00'
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# 対応内容

定期的にSpring Bootのアップデートをしていましたが、手動だと忘れるので他のライブラリも含めて自動で検知できるようにしました。
Github標準のdependabotを使っています。
