### PR TITLE
Spring Boot 2.5にアップグレード

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>2.4.0</version>
+		<version>2.5.0</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>


### PR DESCRIPTION
# 対応内容

2021/5/21にSpring Boot 2.5がリリースされたのでアップデートしました。

ログイン、ログアウト、検索、参照、レコードの登録ができることをサッと確認しています。

# 対応していないこと
`application.properties` に指定しているJDBCドライバが以前から非推奨なのですが、MySQLをやめてh2にする話もあったので修正していません

```
spring.datasource.driverClassName = com.mysql.jdbc.Driver
```

# 関連
Spring Bootは毎回私のTwitterフィードで気がついたら更新しているので、 #34  でアップデート検知を自動にしました