### PR TITLE
Spring Frameworkの非推奨メソッドを利用しない

### DIFF
--- a/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
+++ b/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
@@ -7,7 +7,7 @@ import org.springframework.util.StringUtils;
  * @author subaru
  */
 public class ExampleStringUtils extends StringUtils {
-    public static boolean isNotEmpty(@Nullable Object str) {
-        return !isEmpty(str);
+    public static boolean isNotEmpty(@Nullable String str) {
+        return hasLength(str);
     }
 }

--- a/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
+++ b/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
@@ -4,6 +4,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author subaru
+ * @author y.shimizu
  */
 public class ExampleStringUtils {
     public static boolean isNotEmpty(@Nullable String str) {

--- a/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
+++ b/src/main/java/org/docksidestage/app/utils/ExampleStringUtils.java
@@ -1,13 +1,16 @@
 package org.docksidestage.app.utils;
 
 import org.springframework.lang.Nullable;
-import org.springframework.util.StringUtils;
 
 /**
  * @author subaru
  */
-public class ExampleStringUtils extends StringUtils {
+public class ExampleStringUtils {
     public static boolean isNotEmpty(@Nullable String str) {
-        return hasLength(str);
+        return str != null && !str.isEmpty();
+    }
+
+    public static boolean isEmpty(@Nullable String str) {
+        return str == null || str.isEmpty();
     }
 }

--- a/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
+++ b/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
@@ -19,7 +19,6 @@ import org.docksidestage.dbflute.exentity.Product;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
+++ b/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
@@ -79,10 +79,10 @@ public class ProductController extends ApiBaseController {
             cb.specify().derivedPurchase().count(purchaseCB -> {
                 purchaseCB.specify().columnPurchaseId();
             }, Product.ALIAS_purchaseCount);
-            if (!StringUtils.isEmpty(body.getProductName())) {
+            if (ExampleStringUtils.isNotEmpty(body.getProductName())) {
                 cb.query().setProductName_LikeSearch(body.getProductName(), op -> op.likeContain());
             }
-            if (!StringUtils.isEmpty(body.getPurchaseMemberName())) {
+            if (ExampleStringUtils.isNotEmpty(body.getPurchaseMemberName())) {
                 cb.query().existsPurchase(purchaseCB -> {
                     purchaseCB.query().queryMember().setMemberName_LikeSearch(body.getPurchaseMemberName(), op -> op.likeContain());
                 });

--- a/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
+++ b/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
@@ -30,6 +30,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * @author jflute
+ * @author y.shimizu
  */
 public class GodHandableInterceptor implements AsyncHandlerInterceptor {
 

--- a/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
+++ b/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
@@ -25,13 +25,13 @@ import org.dbflute.hook.AccessContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
  * @author jflute
  */
-public class GodHandableInterceptor extends HandlerInterceptorAdapter {
+public class GodHandableInterceptor implements AsyncHandlerInterceptor {
 
     private static final Logger logger = LoggerFactory.getLogger(GodHandableInterceptor.class);
 
@@ -44,13 +44,12 @@ public class GodHandableInterceptor extends HandlerInterceptorAdapter {
             }
         }
         prepareAccessContext();
-        return super.preHandle(request, response, handler);
+        return true;
     }
 
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView)
             throws Exception {
-        super.postHandle(request, response, handler, modelAndView);
         if (handler instanceof HandlerMethod) {
             if (logger.isDebugEnabled()) {
                 logger.debug("modelAndView: {}", modelAndView != null ? modelAndView.toString() : null);

--- a/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsEmptyTest.java
+++ b/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsEmptyTest.java
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
+/**
+ * @author y.shimizu
+ */
 // POJOのテストなので、JUnitテストの起動のためのアノテーションや継承は必要ない
 public class ExampleStringUtilsIsEmptyTest {
 

--- a/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsEmptyTest.java
+++ b/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsEmptyTest.java
@@ -1,0 +1,31 @@
+package org.docksidestage.app.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+// POJOのテストなので、JUnitテストの起動のためのアノテーションや継承は必要ない
+public class ExampleStringUtilsIsEmptyTest {
+
+    @Test
+    public void test_whenTargetStringIsNull_returnsTrue() {
+        assertThat(ExampleStringUtils.isEmpty(null), is(true));
+    }
+
+    @Test
+    public void test_whenTargetStringIsZeroLengthEmptyString_returnsTrue() {
+        assertThat(ExampleStringUtils.isEmpty(""), is(true));
+    }
+
+    @Test
+    public void test_whenTargetStringIsNonZeroLengthEmptyString_returnsFalse() {
+        assertThat(ExampleStringUtils.isEmpty(" "), is(false));
+    }
+
+    @Test
+    public void test_whenTargetStringIsNonEmptyString_returnsFalse() {
+        assertThat(ExampleStringUtils.isEmpty("Test"), is(false));
+        assertThat(ExampleStringUtils.isEmpty(" Test"), is(false));
+    }
+}

--- a/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsNotEmptyTest.java
+++ b/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsNotEmptyTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
-// ExampleStringUtilsはPOJOなので、JUnitテストの起動のためのアノテーションは必要ない
-public class ExampleStringUtilsTest {
+// POJOのテストなので、JUnitテストの起動のためのアノテーションや継承は必要ない
+public class ExampleStringUtilsIsNotEmptyTest {
 
     @Test
     public void test_whenTargetStringIsNull_returnsFalse() {

--- a/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsNotEmptyTest.java
+++ b/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsIsNotEmptyTest.java
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
+/**
+ * @author y.shimizu
+ */
 // POJOのテストなので、JUnitテストの起動のためのアノテーションや継承は必要ない
 public class ExampleStringUtilsIsNotEmptyTest {
 

--- a/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsTest.java
+++ b/src/test/java/org/docksidestage/app/utils/ExampleStringUtilsTest.java
@@ -1,0 +1,31 @@
+package org.docksidestage.app.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+// ExampleStringUtilsはPOJOなので、JUnitテストの起動のためのアノテーションは必要ない
+public class ExampleStringUtilsTest {
+
+    @Test
+    public void test_whenTargetStringIsNull_returnsFalse() {
+        assertThat(ExampleStringUtils.isNotEmpty(null), is(false));
+    }
+
+    @Test
+    public void test_whenTargetStringIsZeroLengthEmptyString_returnsFalse() {
+        assertThat(ExampleStringUtils.isNotEmpty(""), is(false));
+    }
+
+    @Test
+    public void test_whenTargetStringIsNonZeroLengthEmptyString_returnsTrue() {
+        assertThat(ExampleStringUtils.isNotEmpty(" "), is(true));
+    }
+
+    @Test
+    public void test_whenTargetStringIsNonEmptyString_returnsTrue() {
+        assertThat(ExampleStringUtils.isNotEmpty("Test"), is(true));
+        assertThat(ExampleStringUtils.isNotEmpty(" Test"), is(true));
+    }
+}


### PR DESCRIPTION
# 対応したこと
Spring BootのバージョンアップでSpring Frameworkもバージョンアップされていたので、IDEで非推奨の警告が出ていました。
Spring Frameworkの非推奨メソッドを使わないよう修正しました。

## HandlerInterceptorAdapter
https://spring.pleiades.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/handler/HandlerInterceptorAdapter.html

Javadocに `5.3 の時点で、HandlerInterceptor および AsyncHandlerInterceptor を直接実装することを推奨します。` とあるので、素直に `AsyncHandlerInterceptor` を使いました。

## StringUtils#isEmpty
https://spring.pleiades.io/spring-framework/docs/current/javadoc-api/org/springframework/util/StringUtils.html#isEmpty-java.lang.Object-

ExampleStringUtilsがSpring FrameworkのStringUtilsを継承しており、非推奨メソッドにアクセス出来てしまいました。
継承をやめ、ExampleStringUtilsに同じ処理を実装しました。

こちらはPOJOのテストで導入が簡単なため、JUnitテストを書きました。


# 対応しなかったこと
`SignupValidator` のJUnitテストケースは、ライブラリの追加も必要なので対応していません