### PR TITLE
Spring Boot 2.6.3にアップデート

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>2.5.6</version>
+		<version>2.6.3</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>

--- a/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
+++ b/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.docksidestage.app.application.security;
 
+import org.docksidestage.app.web.signin.SigninService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.ForwardAuthenticationFail
 /**
  * @author inoue on 2016/12/18.
  * @author jflute
+ * @author y.shimizu
  */
 @Configuration
 @EnableWebSecurity
@@ -53,10 +55,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         // @formatter:on
     }
 
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailService).passwordEncoder(passwordEncoder()); // 既存のsampleプロジェクトに合わせる
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService()).passwordEncoder(passwordEncoder());
     }
+
+    @Bean
+    @Override
+    public UserDetailsService userDetailsService() {
+        return new SigninService();
+    }
+
 
     /**
      * パスワードエンコーダを生成する.
@@ -64,7 +73,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
      * harborに合わせてSHA-256を利用する.
      * 非推奨だが削除予定はないのでSpring Security標準付属のエンコーダを利用した.
      *
-     * https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#other-passwordencoders
+     * https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/password/MessageDigestPasswordEncoder.html
      * @return The password encoder for security handling, which is used by framework. (NotNull)
      */
     @SuppressWarnings("deprecation")

--- a/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
+++ b/src/main/java/org/docksidestage/app/application/security/SecurityConfig.java
@@ -21,9 +21,6 @@ import org.springframework.security.web.authentication.ForwardAuthenticationFail
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    private UserDetailsService userDetailService;
-
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         // #for_now for test, enable later by jflute


### PR DESCRIPTION
# 対応したこと

Spring Boot 2.5から2.6にマイナーバージョンアップ

- 2022/01末時点での最新Spring Boot 2.6.3にアップデート
- リンク切れしていたドキュメントのパスを存在するものに修正
- 起動時にDIの循環参照でエラーになるため、UserDetailServiceとPasswordEncoderの登録はconfigureメソッドで行う

# 変更点
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#circular-references-prohibited-by-default
こちらの変更点の影響で `BeanCurrentlyInCreationException` が発生し起動しなくなりました。

configureGlobalメソッドでの設定はSpring Security 4だと公式ドキュメントに言及があるのですが、Spring Security 5.6.1では説明がありませんでした。
公式のJavaDocの通りconfigureメソッドを使っています。

https://spring.pleiades.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.html#configure(org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder)