### PR TITLE
JDK17 + Spring Boot 3にメジャーバージョンアップ

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -18,7 +18,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>2.7.9</version>
+		<version>3.0.3</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>
@@ -65,8 +65,8 @@
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>17</source>
+						<target>17</target>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>3.0.3</version>
+		<version>3.0.5</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>2.7.4</version>
+		<version>2.7.9</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>
@@ -184,6 +184,7 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>runtime</scope>
+			<version>8.0.32</version>
 		</dependency>
 
 		<!-- spring boot -->

--- a/src/main/java/org/docksidestage/app/application/WebAppConfig.java
+++ b/src/main/java/org/docksidestage/app/application/WebAppConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.thymeleaf.dialect.IProcessorDialect;
 
@@ -81,5 +82,15 @@ public class WebAppConfig implements WebMvcConfigurer {
     @Bean
     public IProcessorDialect appProcessorDialect() { // for thymeleaf
         return new AppProcessorDialect("appProcessorDialect", "ex", 1000);
+    }
+
+    /**
+     * スラッシュが最後につく(trailing slash)場合もURLが一致していると判断する
+     * @see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes
+     * @param configurer
+     */
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setUseTrailingSlashMatch(true);
     }
 }

--- a/src/main/java/org/docksidestage/app/web/base/paging/SearchPagingResult.java
+++ b/src/main/java/org/docksidestage/app/web/base/paging/SearchPagingResult.java
@@ -17,8 +17,8 @@ package org.docksidestage.app.web.base.paging;
 
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import org.dbflute.Entity;
 import org.dbflute.cbean.result.PagingResultBean;

--- a/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
+++ b/src/main/java/org/docksidestage/app/web/lido/product/ProductController.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.dbflute.cbean.result.PagingResultBean;
 import org.docksidestage.app.web.base.ApiBaseController;

--- a/src/main/java/org/docksidestage/app/web/member/MemberAddForm.java
+++ b/src/main/java/org/docksidestage/app/web/member/MemberAddForm.java
@@ -2,8 +2,8 @@ package org.docksidestage.app.web.member;
 
 import java.time.LocalDate;
 
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.format.annotation.DateTimeFormat;
 

--- a/src/main/java/org/docksidestage/app/web/member/MemberListController.java
+++ b/src/main/java/org/docksidestage/app/web/member/MemberListController.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.dbflute.cbean.result.PagingResultBean;
 import org.dbflute.util.DfTypeUtil;

--- a/src/main/java/org/docksidestage/app/web/signin/SigninForm.java
+++ b/src/main/java/org/docksidestage/app/web/signin/SigninForm.java
@@ -1,6 +1,6 @@
 package org.docksidestage.app.web.signin;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.hibernate.validator.constraints.Length;
 

--- a/src/main/java/org/docksidestage/app/web/signup/SignupForm.java
+++ b/src/main/java/org/docksidestage/app/web/signup/SignupForm.java
@@ -1,6 +1,6 @@
 package org.docksidestage.app.web.signup;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * @author subaru

--- a/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
+++ b/src/main/java/org/docksidestage/bizfw/GodHandableInterceptor.java
@@ -18,8 +18,8 @@ package org.docksidestage.bizfw;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.dbflute.hook.AccessContext;
 import org.slf4j.Logger;

--- a/src/main/java/org/docksidestage/bizfw/RequestLoggingFilter.java
+++ b/src/main/java/org/docksidestage/bizfw/RequestLoggingFilter.java
@@ -34,16 +34,16 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
# 対応したこと

JDK17 + Spring Boot 3にメジャーバージョンアップしました。

- Spring Boot 3のJavaバージョンは17以上のため、JDK17にバージョンアップできるようpomとIDE設定を更新
- Jakarta EEに変更になるためパッケージを一括置換 
- Spring Security, Spring Frameworkが6にバージョンアップされるので、設定を書き換え
- JDBCドライバが想定外にバージョンアップされないようpomで固定。Springバージョンアップと直接関係ありません。

ブランチ名がPull Requestと違っていますが修正していません。

# 動作確認

- eclipse 2021でJREシステムライブラリをJDK17に変更し、クリーンビルドして起動すること
- IntelliJ Idea Ultimate 2022.3でJava compiler をJDK17に変更し、ビルドして起動すること
- ログイン、ログアウト、各画面の表示、Memberの登録ができること

# 対応しなかったこと

Thymeleafの非推奨構文の修正。将来的に削除されるようなので、別のブランチで修正したいです