### PR TITLE
UTFluteでJava EEを利用しているのでテストスコープで依存性を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,5 +224,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+		<!-- utfluteがJakarta EEに対応できるまで、テストスコープにJ2EEを残しておく -->
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+			<version>8.0.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -226,10 +226,9 @@
         </dependency>
 		<!-- utfluteがJakarta EEに対応できるまで、テストスコープにJ2EEを残しておく -->
 		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>8.0.1</version>
-			<scope>test</scope>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
# 対応したこと

#70 マージ後に `mvn test` を実行すると、ClassNotFoundExceptionが発生していました。

UTFlute内で使われている ` javax.annotation.Reosurce` が存在しなくなっているので、UTFluteでJava 17対応とJakarta EE対応が出来るまでの間はJavaEEを依存性に追加しました。

これで `mvn test` が実行できます。
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.114 s <<< FAILURE! - in org.docksidestage.app.web.signin.LoginServiceTest
[ERROR] warning(junit.framework.TestSuite$1)  Time elapsed: 0.005 s  <<< FAILURE!
junit.framework.AssertionFailedError: 
Exception in constructor: test_loadUserByUsername (java.lang.NoClassDefFoundError: javax/annotation/Resource
        at org.dbflute.utflute.spring.SpringTestCase.xprovideBindingAnnotationRuleMap(SpringTestCase.java:187)
```