### PR TITLE
Spring Boot 4へメジャーバージョンアップする準備で、Spring Bootを3.5の最新3.5.12にバージョンアップ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: daily
       time: '21:00'
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
       time: '21:00'
     open-pull-requests-limit: 5

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<!-- Spring Bootのバージョンはここのparentで、それ以外のバージョンはpropertiesでまとめて指定する -->
-		<version>3.0.5</version>
+		<version>3.5.12</version>
 	</parent>
 
 	<groupId>org.dbflute.example</groupId>


### PR DESCRIPTION
Spring Boot 4へメジャーバージョンアップできるよう、3.5の最新にバージョンアップしています

Upgrade to the Latest 3.5.x Version
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide

2026/3/19 に公開された3.5.12にバージョンアップしました。

https://spring.io/blog/2026/03/19/spring-boot-3-5-12-available-now

Spring Boot 4へのメジャーバージョンアップはまだ対応していません。JDKのメジャーバージョンアップが必要なため。